### PR TITLE
Added support for transactions endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,28 @@
 # Changelog
 
+## v0.6.0: 25/06/2020
+
+Added missing keyword support for ComfortPay service.
+
 ## v0.5.0: 24/09/2019
 
 Renamed package to `cheddarpayments`, open sourced at GitHub and released to PyPI.
 
 ## v0.4.0: 06/09/2019
 
-Rearchitecting API to be a bit more Pythonic with Python 3.4+ compatibility. Code formatting is covered by Black and various small fixes to make everything better and easier including first test.
+Rearchitecting API to be a bit more Pythonic with Python 3.4+ compatibility. Code formatting is covered by Black and
+various small fixes to make everything better and easier including first test.
 
 ## v0.3.1: 24/08/2016
 
-Added the ability to set `X-Real-IP` header with user's 'IP address. The IP should be set as `ip_address` property on `cheddar` class.
+Added the ability to set `X-Real-IP` header with user's 'IP address. The IP should be set as `ip_address` property on
+`cheddar` class.
 
 ## v0.3.0: 08/05/2016
 
-Aded support for Poštová banka's iTerminal and a note in the documentation about changing the endpoint URL to either sandbox or completely different Cheddar instance. Production URL for the service has also changed to [cheddarpayments.com](https://www.cheddarpayments.com).
+Added support for Poštová banka's iTerminal and a note in the documentation about changing the endpoint URL to either
+sandbox or completely different Cheddar instance. Production URL for the service has also changed to
+[cheddarpayments.com](https://www.cheddarpayments.com).
 
 ## v0.2.4: 07/09/2015
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ First argument is a service provider, which can currently be one of the followin
 |`cheddar.Service.SPOROPAY`|SporoPay, Slovenská sporiteľňa|
 |`cheddar.Service.TATRAPAY`|TatraPay, Tatra banka|
 |`cheddar.Service.CARDPAY`|Cardpay, Tatra banka|
+|`cheddar.Service.COMFORTPAY`|ComfortPay (periodic payments), Tatra banka|
 |`cheddar.Service.EPLATBY`|ePlatby, VÚB|
 |`cheddar.Service.ECARD`|eCard, VÚB|
 |`cheddar.Service.PAYPAL`|PayPal Payments Standard, PayPal|

--- a/cheddar/cheddar.py
+++ b/cheddar/cheddar.py
@@ -6,6 +6,7 @@ from .configuration import Configuration
 from .errors import ConfigurationError
 from .messages import Messages
 from .payments import Payments
+from .transactions import Transactions
 from .requestor import Requestor
 from .version import VERSION
 
@@ -15,12 +16,13 @@ class Cheddar(object):
         if isinstance(configuration, Configuration):
             self.configuration = configuration
         else:
-            raise ConfigurationError("aaa")
+            raise ConfigurationError("Missing configuration object")
 
         self.version = VERSION
         self.requestor = Requestor(self)
         self.payments = Payments(self)
         self.messages = Messages(self)
+        self.transactions = Transactions(self)
 
     def identifier(self):
         return "cheddar-python/%s" % self.version

--- a/cheddar/payments.py
+++ b/cheddar/payments.py
@@ -44,11 +44,11 @@ class Payments(object):
 
         return Payment(response)
 
-    def refund(self, uuid):
+    def refund(self, uuid, refund):
         data = {"refund": refund}
 
         status_code, response = self.requestor.request(
-            "post", "/api/v1/payments/%s/refund" % (uuid), data
+            "post", "/api/v1/payments/%s/refund" % uuid, data
         )
 
         return Payment(response)

--- a/cheddar/resources/service.py
+++ b/cheddar/resources/service.py
@@ -9,6 +9,7 @@ class Service(object):
     EPLATBY = "eplatby"
     TATRAPAY = "tatrapay"
     CARDPAY = "cardpay"
+    COMFORTPAY = "comfortpay"
     PAYPAL = "paypal"
     GPWEBPAY = "gpwebpay"
     ITERMINAL = "iterminal"

--- a/cheddar/resources/transaction.py
+++ b/cheddar/resources/transaction.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function
+
+
+class Transaction(object):
+    def __init__(self, data):
+        self.uuid = data['uuid']
+        self.type = data['type']
+        self.payment_uuid = data['payment']
+        self.bank_identifier = data['bank_identifier']
+
+        self.variable_symbol = data['variable_symbol'] if 'variable_symbol' in data else None
+        self.constant_symbol = data['constant_symbol'] if 'constant_symbol' in data else None
+        self.specific_symbol = data['specific_symbol'] if 'specific_symbol' in data else None
+
+        self.amount = data['amount']
+        self.currency = data["currency"]
+
+        self.iban = data['iban'] if 'iban' in data else None
+        self.notes = data['notes'] if 'notes' in data else None
+        self.description = data['description'] if 'description' in data else None
+
+        self.booked_at = data['booked_at'] if 'booked_at' in data else None
+        self.created_at = data['created_at'] if 'created_at' in data else None
+
+    def __str__(self):
+        return str(self.__dict__)
+
+
+class TransactionResponse(object):
+    class Metadata(object):
+        def __init__(self, data):
+            self.page = data.get('page')
+            self.pages = data.get('pages')
+            self.total = data.get('total')
+
+    def __init__(self, transactions, metadata):
+        self.transactions = transactions
+        self.metadata = self.Metadata(metadata)

--- a/cheddar/transactions.py
+++ b/cheddar/transactions.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function
+
+from .resources.transaction import Transaction, TransactionResponse
+
+
+class Transactions(object):
+    def __init__(self, client):
+        self.requestor = client.requestor
+        self.configuration = client.configuration
+
+    def all(self, page=None, limit=None, before=None, after=None):
+        filters = {}
+
+        if page:
+            filters['page'] = page
+
+        if limit:
+            filters['limit'] = limit
+
+        if before:
+            filters['created_before'] = before.isoformat()
+
+        if after:
+            filters['created_after'] = after.isoformat()
+
+        status_code, response = self.requestor.request("get", "/api/v1/transactions/", query=filters)
+
+        return TransactionResponse(
+            list(map(Transaction, response.get('transactions', []))),
+            response.get('metadata', {})
+        )
+
+    def detail(self, uuid):
+        status_code, response = self.requestor.request("get", "/api/v1/transactions/%s" % uuid)
+        return Transaction(response)

--- a/cheddar/version.py
+++ b/cheddar/version.py
@@ -1,1 +1,1 @@
-VERSION = "0.5.0"
+VERSION = "0.6.0"

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ envlist = py27,
           py35,
           py36,
           py37,
+          py38,
           pypy,
           pypy3,
           lint
@@ -29,5 +30,5 @@ skip_install = true
 description = run static analysis and style check using flake8
 basepython = python2.7
 deps = flake8
-commands = python -m flake8 --show-source stripe tests setup.py {posargs}
+commands = python -m flake8 --show-source tests setup.py {posargs}
 skip_install = true


### PR DESCRIPTION
I have created a simple functions to support listing a retreiving details of Cheddar transactions.

Here is an example usage:

```python
response = client.transactions.all(
    page=1,
    limit=10
)

print(response.metadata)

for item in response.transactions:
    print(item.payment_uuid)
```

I have tried to keep support for Python 2.7 (I hope successfully). I had to change also few lines in `Requestor` objects, because of request signing. 